### PR TITLE
Fixed Back Action Button of NoteEditorActivity.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,7 +16,9 @@
             </intent-filter>
         </activity>
         <activity android:name=".activities.NoteEditorActivity" />
-        <activity android:name=".NoteEditorActivity"></activity>
+        <activity android:name=".NoteEditorActivity"
+            android:parentActivityName=".MainActivity" >
+        </activity>
     </application>
 
 </manifest>

--- a/app/src/main/java/www/mnnit/com/notepod/NoteEditorActivity.java
+++ b/app/src/main/java/www/mnnit/com/notepod/NoteEditorActivity.java
@@ -2,6 +2,7 @@ package www.mnnit.com.notepod;
 
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
+import android.support.v4.app.NavUtils;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.support.v7.widget.Toolbar;
@@ -55,6 +56,11 @@ public class NoteEditorActivity extends AppCompatActivity {
             return true;
         }
 
+        //Go back to MainActivity
+        if(id==android.R.id.home){
+            NavUtils.navigateUpFromSameTask(this);
+            return true;
+        }
         return super.onOptionsItemSelected(item);
     }
 


### PR DESCRIPTION
Set MainActivity as Parent of NoteEditorActivity in manifest file and also handled the NavigateUpTask.
The NoteEditorActivity Back Action Button works now.